### PR TITLE
fix: make all single item __all__s tuples

### DIFF
--- a/EpikCord/application/application.py
+++ b/EpikCord/application/application.py
@@ -23,4 +23,4 @@ class Application:
         self.flags: int = data.get("flags")
 
 
-__all__ = "Application"
+__all__ = ("Application",)

--- a/EpikCord/user.py
+++ b/EpikCord/user.py
@@ -26,4 +26,4 @@ class User(Messageable):
         self.public_flags: int = data.get("public_flags")
 
 
-__all__ = "User"
+__all__ = ("User",)


### PR DESCRIPTION
## Description

`__all__` must be `tuple[str, ...]`, this PR fixes the two
<!--Describe your pull request here-->

## Checklist

<!--To check an item in the checklist, put an x between the square brackets without spaces. Like - [x]-->

- [ ] - All code changes have been tested, if any
- [ ] - The documentation has been updated accordingly for any code changes
- [ ] - This PR fixes an already existing issue
- [ ] - This PR adds a new feature (new functions, methods, classes, parameters, etc.)
- [ ] - This PR fixes a bug
- [ ] - This PR is a breaking change (removes/renames functions, parameters etc.)
- [ ] - This PR is NOT a code change (changes Documentation files, README.md, CONTRIBUTING.md etc.)

## Additional context

`Operation on "__all__" is not supported, so exported symbol list may be incorrect (PylancereportUnsupportedDunderAll)`
<!--This is optional, provide some more context on your pull request here-->
